### PR TITLE
feat: add action to generate CRD md documentation from yaml

### DIFF
--- a/generate-crd-docs/Dockerfile
+++ b/generate-crd-docs/Dockerfile
@@ -1,0 +1,13 @@
+FROM golang:1.17-bullseye
+
+
+RUN apt-get update && apt-get install -y git curl apt-transport-https
+RUN curl https://baltocdn.com/helm/signing.asc | apt-key add - && \
+    echo "deb https://baltocdn.com/helm/stable/debian/ all main" | tee /etc/apt/sources.list.d/helm-stable-debian.list  && \
+    apt-get update && \
+    apt-get install -y helm
+RUN go install fybrik.io/crdoc@v0.5.2
+
+WORKDIR /action
+
+CMD crdoc --resources ${RESOURCES} --output ${OUTPUT}

--- a/generate-crd-docs/README.md
+++ b/generate-crd-docs/README.md
@@ -1,0 +1,4 @@
+# Generate CRD documentation
+
+A simple docker action that generates a markdown documentation from a CRD yaml.
+Uses [crdoc](https://github.com/fybrik/crdoc).

--- a/generate-crd-docs/action.yaml
+++ b/generate-crd-docs/action.yaml
@@ -1,0 +1,8 @@
+name: "generate-crd-docs"
+description: "Generate Markdown documentation from CRDs. Uses https://github.com/fybrik/crdoc."
+runs:
+  using: "docker"
+  image: "Dockerfile"
+branding:
+  icon: "activity"
+  color: "blue"


### PR DESCRIPTION
See https://github.com/SwissDataScienceCenter/amalthea/pull/78 and in particular https://github.com/SwissDataScienceCenter/amalthea/blob/000-crd-docs2/docs/crd.md for an example of this action in use.