### PR TITLE
feat: specify chartpress.yaml location when publishing

### DIFF
--- a/publish-chart/README.md
+++ b/publish-chart/README.md
@@ -26,12 +26,13 @@ published to.
 
 You can set these environment variables:
 
-| Variable name | Default | Required |
-| --------------| --------| ---------|
-| CHART_DIR    | helm-chart/ | No |
-| DOCKER_PASSWORD | None | Yes |
-| DOCKER_USERNAME | None | Yes |
-| GIT_EMAIL     | None | Yes |
-| GIT_USER      | None | Yes |
-| GITHUB_TOKEN  | None | Yes |
-| IMAGE_PREFIX  | None | No  |
+| Variable name        | Default     | Required |
+| -------------------- | ----------- | ---------|
+| CHART_DIR            | helm-chart/ | No       |
+| DOCKER_PASSWORD      | None        | Yes      |
+| DOCKER_USERNAME      | None        | Yes      |
+| GIT_EMAIL            | None        | Yes      |
+| GIT_USER             | None        | Yes      |
+| GITHUB_TOKEN         | None        | Yes      |
+| IMAGE_PREFIX         | None        | No       |
+| CHARTPRESS_SPEC_DIR  | .           | No       |

--- a/publish-chart/publish-chart.sh
+++ b/publish-chart/publish-chart.sh
@@ -33,6 +33,10 @@ if [ ! -z "$IMAGE_PREFIX" ]; then
   IMAGE_PREFIX="--image-prefix ${IMAGE_PREFIX}"
 fi
 
+if [ -z "$CHARTPRESS_SPEC_DIR" ]; then
+  CHARTPRESS_SPEC_DIR="."
+fi
+
 # set up git
 git config --global user.email "$GIT_EMAIL"
 git config --global user.name "$GIT_USER"
@@ -43,4 +47,5 @@ helm dep update $CHART_DIR/$CHART_NAME
 echo ${DOCKER_PASSWORD} | docker login -u ${DOCKER_USERNAME} --password-stdin
 
 # build and push the chart and images
+cd $CHARTPRESS_SPEC_DIR
 chartpress --push --publish-chart $CHART_TAG $IMAGE_PREFIX


### PR DESCRIPTION
This allows the location of the chartpress.yaml file to be specified when publishing a helm chart with chartpress.

Chartpress works only when the chartpress.yaml file is located where the chartpress command is run.

But if you have a repo where you have multiple chartpress.yaml files or you have them in a non-standard location this is useful.

