### PR TITLE
fix: deploy renku action

### DIFF
--- a/deploy-renku/entrypoint.sh
+++ b/deploy-renku/entrypoint.sh
@@ -28,7 +28,6 @@ fi
 
 NAMESPACE_EXISTS=$( curl -s -H "Authorization: Bearer $RENKUBOT_RANCHER_BEARER_TOKEN" \
       -X GET \
-      -d "projectId=${RANCHER_PROJECT_ID}" \
       "${RANCHER_DEV_API_ENDPOINT}/namespaces?projectId=${RANCHER_PROJECT_ID}" | grep $RENKU_NAMESPACE)
 if test -z "$NAMESPACE_EXISTS" ; then
   curl -s -H "Authorization: Bearer $RENKUBOT_RANCHER_BEARER_TOKEN" \

--- a/deploy-renku/entrypoint.sh
+++ b/deploy-renku/entrypoint.sh
@@ -26,12 +26,12 @@ if [[ -n "$GITLAB_TOKEN" ]]; then
   yq w -i $RENKU_VALUES_FILE "gateway.gitlabClientSecret" "$APP_SECRET"
 fi
 
-NAMESPACE_EXISTS=$( curl -f -s -H "Authorization: Bearer $RENKUBOT_RANCHER_BEARER_TOKEN" \
+NAMESPACE_EXISTS=$( curl -s -H "Authorization: Bearer $RENKUBOT_RANCHER_BEARER_TOKEN" \
       -X GET \
       -d "projectId=${RANCHER_PROJECT_ID}" \
-      "${RANCHER_DEV_API_ENDPOINT}/namespaces"| grep $RENKU_NAMESPACE)
-if [[ ! -n $NAMESPACE_EXISTS ]]; then
-  curl -f -s -H "Authorization: Bearer $RENKUBOT_RANCHER_BEARER_TOKEN" \
+      "${RANCHER_DEV_API_ENDPOINT}/namespaces" | grep $RENKU_NAMESPACE)
+if test -z "$NAMESPACE_EXISTS" ; then
+  curl -s -H "Authorization: Bearer $RENKUBOT_RANCHER_BEARER_TOKEN" \
       -X POST \
       -d "name=${RENKU_NAMESPACE}" \
       -d "projectId=${RANCHER_PROJECT_ID}" \

--- a/deploy-renku/entrypoint.sh
+++ b/deploy-renku/entrypoint.sh
@@ -28,7 +28,8 @@ fi
 
 NAMESPACE_EXISTS=$( curl -s -H "Authorization: Bearer $RENKUBOT_RANCHER_BEARER_TOKEN" \
       -X GET \
-      "${RANCHER_DEV_API_ENDPOINT}/namespaces?projectId=${RANCHER_PROJECT_ID}"| grep $RENKU_NAMESPACE)
+      -d "projectId=${RANCHER_PROJECT_ID}" \
+      "${RANCHER_DEV_API_ENDPOINT}/namespaces"| grep $RENKU_NAMESPACE)
 if [[ ! -n $NAMESPACE_EXISTS ]]; then
   curl -s -H "Authorization: Bearer $RENKUBOT_RANCHER_BEARER_TOKEN" \
       -X POST \

--- a/deploy-renku/entrypoint.sh
+++ b/deploy-renku/entrypoint.sh
@@ -26,12 +26,12 @@ if [[ -n "$GITLAB_TOKEN" ]]; then
   yq w -i $RENKU_VALUES_FILE "gateway.gitlabClientSecret" "$APP_SECRET"
 fi
 
-NAMESPACE_EXISTS=$( curl -s -H "Authorization: Bearer $RENKUBOT_RANCHER_BEARER_TOKEN" \
+NAMESPACE_EXISTS=$( curl -f -s -H "Authorization: Bearer $RENKUBOT_RANCHER_BEARER_TOKEN" \
       -X GET \
       -d "projectId=${RANCHER_PROJECT_ID}" \
       "${RANCHER_DEV_API_ENDPOINT}/namespaces"| grep $RENKU_NAMESPACE)
 if [[ ! -n $NAMESPACE_EXISTS ]]; then
-  curl -s -H "Authorization: Bearer $RENKUBOT_RANCHER_BEARER_TOKEN" \
+  curl -f -s -H "Authorization: Bearer $RENKUBOT_RANCHER_BEARER_TOKEN" \
       -X POST \
       -d "name=${RENKU_NAMESPACE}" \
       -d "projectId=${RANCHER_PROJECT_ID}" \

--- a/deploy-renku/entrypoint.sh
+++ b/deploy-renku/entrypoint.sh
@@ -12,7 +12,7 @@ echo "$RENKUBOT_KUBECONFIG" > "$KUBECONFIG" && chmod 400 "$KUBECONFIG"
 printf "%s" "$RENKU_VALUES" | sed "s/<replace>/${RENKU_RELEASE}/" > $RENKU_VALUES_FILE
 
 # register the GitLab app
-if [[ -n "$GITLAB_TOKEN" ]]; then
+if test -n "$GITLAB_TOKEN" ; then
   gitlab_app=$(curl -s -X POST https://dev.renku.ch/gitlab/api/v4/applications \
                         -H "private-token: $GITLAB_TOKEN" \
                         --data "name=${RENKU_RELEASE}" \
@@ -29,7 +29,7 @@ fi
 NAMESPACE_EXISTS=$( curl -s -H "Authorization: Bearer $RENKUBOT_RANCHER_BEARER_TOKEN" \
       -X GET \
       -d "projectId=${RANCHER_PROJECT_ID}" \
-      "${RANCHER_DEV_API_ENDPOINT}/namespaces" | grep $RENKU_NAMESPACE)
+      "${RANCHER_DEV_API_ENDPOINT}/namespaces?projectId=${RANCHER_PROJECT_ID}" | grep $RENKU_NAMESPACE)
 if test -z "$NAMESPACE_EXISTS" ; then
   curl -s -H "Authorization: Bearer $RENKUBOT_RANCHER_BEARER_TOKEN" \
       -X POST \


### PR DESCRIPTION
So the problem was that the if statement here was not working in alpine with a more stricter posix shell interpreter but was working fine when testing locally.

After running in the same docker image as this action I could reproduce the error.

I used [this guide](https://thoughtbot.com/blog/the-unix-shells-humble-if#the-test-command) to get a "proper posix shell syntax" for the if statement.

Tested here: https://github.com/SwissDataScienceCenter/renku-notebooks/runs/4347544686?check_suite_focus=true

It works.

Version 0.3.0 worked because the if statement was a bit different and this either triggered all the time or just triggered properly. Changing the if statement syntax was the problem - not the credentials in the secrets.