### PR TITLE
chore: update action that updates actions

### DIFF
--- a/.github/workflows/update-on-new-release.yaml
+++ b/.github/workflows/update-on-new-release.yaml
@@ -32,7 +32,7 @@ jobs:
         ref: ${{ matrix.repo.ref }}
         fetch-depth: 1
     - name: Update actions version
-      uses: SwissDataScienceCenter/renku-actions/update-renku-actions@v0.3.2
+      uses: SwissDataScienceCenter/renku-actions/update-renku-actions@v0.4.0
     - name: Submit PR
       uses: peter-evans/create-pull-request@v3
       with:


### PR DESCRIPTION
Minor changes so that the action that updates all the other actions in other repos is tracking the latest version.

Also the draft release for the new version of the actions is here:
https://github.com/SwissDataScienceCenter/renku-actions/releases/tag/untagged-cf9b6808bba1e064bca7