### PR TITLE
fix: change versions of child actions test-renku

### DIFF
--- a/test-renku/action.yml
+++ b/test-renku/action.yml
@@ -37,7 +37,7 @@ runs:
         TEST_TIMEOUT_MINS: ${{ inputs.test-timeout-mins }}
     - name: Download artifact for packaging on failure
       if: failure()
-      uses: SwissDataScienceCenter/renku-actions/download-test-artifacts@test-and-cleanup-action
+      uses: SwissDataScienceCenter/renku-actions/download-test-artifacts@v0.4.1
       env:
         RENKU_VALUES: ${{ inputs.ci-renku-values }}
         TEST_ARTIFACTS_PATH: "tests-artifacts-${{ github.sha }}"
@@ -48,7 +48,7 @@ runs:
         name: acceptance-test-artifacts
         path: ${{ github.workspace }}/test-artifacts/
     - name: "Cleanup CI deployment after test if persist flag set to false"
-      uses: SwissDataScienceCenter/renku-actions/cleanup-renku-ci-deployments@test-and-cleanup-action
+      uses: SwissDataScienceCenter/renku-actions/cleanup-renku-ci-deployments@v0.4.1
       if: ${{ always() && inputs.persist == 'false' }}
       env:
         RENKUBOT_KUBECONFIG: ${{ inputs.renkubot-kubeconfig }}


### PR DESCRIPTION
Noticed that I forgot to properly update the pinned versions of the child actions in the large renku-test composite action.