### PR TITLE
chore: create ci ns independent of rancher

### DIFF
--- a/deploy-renku/README.md
+++ b/deploy-renku/README.md
@@ -28,14 +28,11 @@ deploy-pr:
       DOCKER_USERNAME: ${{ secrets.RENKU_DOCKER_USERNAME }}
       GITLAB_TOKEN: ${{ secrets.DEV_GITLAB_TOKEN }}
       KUBECONFIG: "${{ github.workspace }}/renkubot-kube.config"
-      RANCHER_PROJECT_ID: ${{ secrets.CI_RANCHER_PROJECT }}
       RENKU_ANONYMOUS_SESSIONS: true
       RENKU_RELEASE: ci-renku-${{ github.event.number }}
       RENKU_VALUES_FILE: "${{ github.workspace }}/values.yaml"
       RENKU_VALUES: ${{ secrets.CI_RENKU_VALUES }}
       RENKUBOT_KUBECONFIG: ${{ secrets.RENKUBOT_DEV_KUBECONFIG }}
-      RENKUBOT_RANCHER_BEARER_TOKEN: ${{ secrets.RENKUBOT_RANCHER_BEARER_TOKEN }}
-      RANCHER_DEV_API_ENDPOINT: ${{ secrets.RANCHER_DEV_API_ENDPOINT }}
       TEST_ARTIFACTS_PATH: "tests-artifacts-${{ github.sha }}"
       renku: "@${{ github.head_ref }}"
       renku_core: "${{ needs.check-deploy.outputs.renku-core }}"

--- a/deploy-renku/entrypoint.sh
+++ b/deploy-renku/entrypoint.sh
@@ -26,16 +26,8 @@ if test -n "$GITLAB_TOKEN" ; then
   yq w -i $RENKU_VALUES_FILE "gateway.gitlabClientSecret" "$APP_SECRET"
 fi
 
-NAMESPACE_EXISTS=$( curl -s -H "Authorization: Bearer $RENKUBOT_RANCHER_BEARER_TOKEN" \
-      -X GET \
-      "${RANCHER_DEV_API_ENDPOINT}/namespaces?projectId=${RANCHER_PROJECT_ID}" | grep $RENKU_NAMESPACE)
-if test -z "$NAMESPACE_EXISTS" ; then
-  curl -s -H "Authorization: Bearer $RENKUBOT_RANCHER_BEARER_TOKEN" \
-      -X POST \
-      -d "name=${RENKU_NAMESPACE}" \
-      -d "projectId=${RANCHER_PROJECT_ID}" \
-      "${RANCHER_DEV_API_ENDPOINT}/namespaces"
-fi
+# create namespace and ignore error in case it already exists
+kubectl create namespace ${RENKU_NAMESPACE} || true
 
 # deploy renku - reads config from environment variables
 helm repo add renku https://swissdatasciencecenter.github.io/helm-charts


### PR DESCRIPTION
Now that all devs including renkubot are admins in the dev cluster, this allows us to simplify things quite a bit.

Deploy action seems to work, see https://github.com/SwissDataScienceCenter/renku/pull/2444.