### PR TITLE
chore(ci): use org level renkubot github token

### DIFF
--- a/.github/workflows/update-on-new-release.yaml
+++ b/.github/workflows/update-on-new-release.yaml
@@ -36,7 +36,7 @@ jobs:
     - name: Submit PR
       uses: peter-evans/create-pull-request@v3
       with:
-        token: ${{ secrets.RENKU_ACTIONS_GITHUB_TOKEN }}
+        token: ${{ secrets.RENKUBOT_GITHUB_TOKEN }}
         commit-message: "chore(ci): Update renku actions to ${{ env.NEW_VERSION }}"
         title: "chore(ci): Update renku actions to ${{ env.NEW_VERSION }}"
         branch: "chore-update-renku-action-${{ env.NEW_VERSION }}"


### PR DESCRIPTION
So I initially used one of my own tokens for updating the renku actions versions.

But it is better to use the renkubot one. So now it should fully appear as if the bot is opening the PR - not me.