### PR TITLE
fix: fully cleanup namespaces from CI deployments

### DIFF
--- a/cleanup-renku-ci-deployments/entrypoint.sh
+++ b/cleanup-renku-ci-deployments/entrypoint.sh
@@ -23,56 +23,62 @@ echo "$RENKUBOT_KUBECONFIG" > "$KUBECONFIG" && chmod 400 "$KUBECONFIG"
 echo "Kubeconfig is at $KUBECONFIG."
 echo "Kubeconfig is $KUBECONFIG_LINES long."
 echo "Looking for CI releases with regex $HELM_RELEASE_REGEX."
-echo "Looking in namespaces with regex $K8S_CI_NAMESPACE_REGEX."
+echo "Looking in namespaces with regex $HELM_RELEASE_REGEX."
 echo "Age threshold for deletion is $MAX_AGE_SECONDS seconds."
 echo "Delete namespace: $DELETE_NAMESPACE"
 
 NOW=$(date +%s)
-# get a list of all applicable releases
-RELEASES_JSON=$(helm list --all-namespaces --all -f "$HELM_CI_RELEASE_REGEX" -o json | jq -cr "map(select((.name | test(\"$HELM_RELEASE_REGEX\")) and (.namespace | test(\"$K8S_CI_NAMESPACE_REGEX\"))))")
-RELEASES_JSON_INDS=$(echo $RELEASES_JSON | jq -r 'length as $arr_len | range($arr_len)')
-for RELEASE_JSON_IND in $RELEASES_JSON_INDS
+NAMESPACES=$(kubectl get namespaces -o json | jq -cr ".items | map(select(.metadata.name | test(\"$K8S_CI_NAMESPACE_REGEX\"))) | .[].metadata.name")
+for NAMESPACE in NAMESPACES 
 do
-    RELEASE=$(echo $RELEASES_JSON | jq -r ".[$RELEASE_JSON_IND].name")
-    NAMESPACE=$(echo $RELEASES_JSON | jq -r ".[$RELEASE_JSON_IND].namespace")
-    if [ ! -z $RELEASE ] && [ ! -z $NAMESPACE ]
-    then
-        echo "Checking release $RELEASE in namespace $NAMESPACE."
-        # extract last deployed date and convert to unix epoch
-        LAST_DEPLOYED_AT=$(helm -n $NAMESPACE history $RELEASE -o json | jq -r 'last | .updated | sub("\\.[0-9]{6}.*$"; "Z") | fromdateiso8601')
-        AGE_SECONDS=$(expr $NOW - $LAST_DEPLOYED_AT)
-        if [ $AGE_SECONDS -ge $MAX_AGE_SECONDS ] || [ $MAX_AGE_SECONDS -le 0 ]
+    RELEASES=$(helm list -n $NAMESPACE --all -f "$HELM_CI_RELEASE_REGEX" -o json | jq -cr "map(select(.name | test(\"$HELM_RELEASE_REGEX\"))) | .[].name")
+    for RELEASE in $RELEASES
+    do
+        if [ ! -z $RELEASE ] && [ ! -z $NAMESPACE ]
         then
-            # remove any jupyterservers - they have finalizers that prevent the namespces to be deleted
-            SERVERS=$(kubectl -n $NAMESPACE get jupyterservers -o json | jq -r '.items | .[].metadata.name') 
-            for SERVER in $SERVERS
-            do
-                echo "Deleting jupyterserver $SERVER in namespace $NAMESPACE."
-                kubectl -n $NAMESPACE delete --wait --cascade="foreground" jupyterserver
-            done
-            # remove the gitlab app
-            APPS=$(curl -s ${GITLAB_URL}/api/v4/applications -H "private-token: ${GITLAB_TOKEN}" | jq -r ".[] | select(.application_name == \"${RELEASE}\") | .id")
-            for APP in $APPS
-            do
-                echo "Deleting Gitlab application client $APP."
-                curl -X DELETE ${GITLAB_URL}/api/v4/applications/${APP} -H "private-token: ${GITLAB_TOKEN}"
-            done
-            # delete the helm chart
-            echo "Deleting release $RELEASE in namespace $NAMESPACE, with age $AGE_SECONDS."
-            helm -n $NAMESPACE delete $RELEASE
-            # wait for helm release to be fully deleted
-            kubectl -n $NAMESPACE get deployments -o json | jq -r '.items | .[].metadata.name' | xargs -r kubectl -n $NAMESPACE wait --for=delete deployment
-            kubectl -n $NAMESPACE get statefulsets -o json | jq -r '.items | .[].metadata.name' | xargs -r kubectl -n $NAMESPACE wait --for=delete statefulset
-            if [ "$DELETE_NAMESPACE" = "true" ] 
+            echo "Checking release $RELEASE in namespace $NAMESPACE."
+            # extract last deployed date and convert to unix epoch
+            LAST_DEPLOYED_AT=$(helm -n $NAMESPACE history $RELEASE -o json | jq -r 'last | .updated | sub("\\.[0-9]{6}.*$"; "Z") | fromdateiso8601')
+            AGE_SECONDS=$(expr $NOW - $LAST_DEPLOYED_AT)
+            if [ $AGE_SECONDS -ge $MAX_AGE_SECONDS ] || [ $MAX_AGE_SECONDS -le 0 ]
             then
-                # remove the namespace
-                echo "Deleting namespace $NAMESPACE"
-                kubectl delete namespace $NAMESPACE --wait
+                # remove any jupyterservers - they have finalizers that prevent the namespces to be deleted
+                SERVERS=$(kubectl -n $NAMESPACE get jupyterservers -o json | jq -r '.items | .[].metadata.name') 
+                for SERVER in $SERVERS
+                do
+                    echo "Deleting jupyterserver $SERVER in namespace $NAMESPACE."
+                    kubectl -n $NAMESPACE delete --wait --cascade="foreground" jupyterserver
+                done
+                # remove the gitlab app
+                APPS=$(curl -s ${GITLAB_URL}/api/v4/applications -H "private-token: ${GITLAB_TOKEN}" | jq -r ".[] | select(.application_name == \"${RELEASE}\") | .id")
+                for APP in $APPS
+                do
+                    echo "Deleting Gitlab application client $APP."
+                    curl -X DELETE ${GITLAB_URL}/api/v4/applications/${APP} -H "private-token: ${GITLAB_TOKEN}"
+                done
+                # delete the helm chart
+                echo "Deleting release $RELEASE in namespace $NAMESPACE, with age $AGE_SECONDS."
+                helm -n $NAMESPACE delete $RELEASE
+                # wait for helm release to be fully deleted
+                kubectl -n $NAMESPACE get deployments -o json | jq -r '.items | .[].metadata.name' | xargs -r kubectl -n $NAMESPACE wait --for=delete deployment
+                kubectl -n $NAMESPACE get statefulsets -o json | jq -r '.items | .[].metadata.name' | xargs -r kubectl -n $NAMESPACE wait --for=delete statefulset
+                # remove the namespace if required
+                if [ "$DELETE_NAMESPACE" = "true" ]
+                then
+                    echo "Deleting namespace $NAMESPACE"
+                    kubectl delete namespace $NAMESPACE --wait
+                fi
+            else
+                echo "Release $RELEASE in namespace $NAMESPACE age is $AGE_SECONDS, not >= to $MAX_AGE_SECONDS, skipping."
             fi
         else
-            echo "Release $RELEASE in namespace $NAMESPACE age is $AGE_SECONDS, not >= to $MAX_AGE_SECONDS, skipping."
+            echo "Release $RELEASE and/or $NAMEPSACE are empty."
         fi
-    else
-        echo "Release $RELEASE and/or $NAMEPSACE are empty. Skipping."
+    done
+    if [ "$DELETE_NAMESPACE" = "true" ] && [ ! -z $NAMESPACE ] && [ -z $RELEASES ]
+    then
+        # remove the namespace if there are no releases in it
+        echo "Deleting namespace $NAMESPACE"
+        kubectl delete namespace $NAMESPACE --wait
     fi
 done


### PR DESCRIPTION
So the problem with the action was as follows, when a CI deployment does not have `#persist` then the CI deployment is deleted as soon as the tests finish. But the namespace is left until the PR is closed. However the main deletion logic in the action was based on looping over helm releases. So if there is no helm release it would do nothing. So when the PR is closed the only thing left to clean up is the namespace - there is no helm release. So the action would leave the namespaces out.

Now the logic loops first through the namespaces and then through the releases. So even if a release is not there it can catch the existence of an empty namespace and delete the namespace.

See test action: https://github.com/SwissDataScienceCenter/renku-notebooks/runs/5286353491?check_suite_focus=true#step:4:18

This is related to this PR: https://github.com/SwissDataScienceCenter/renku-notebooks/pull/943

To fully test I did the following:
1. Open the PR, tag with `/deploy`
2. Wait for the tests to finish and then for the cleanup to remove the helm release
3. Close the PR (previously the cleanup action that triggers on close would leave the namespace, not it deletes it)