### PR TITLE
chore(ci): correct branch for action update

### DIFF
--- a/.github/workflows/update-on-new-release.yaml
+++ b/.github/workflows/update-on-new-release.yaml
@@ -25,14 +25,19 @@ jobs:
     steps:
     - name: Get release tag
       run: echo "NEW_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
-    - name: Checkout code
+    - name: Checkout repo to be updated
       uses: actions/checkout@v2
       with:
         repository: ${{ matrix.repo.name }}
         ref: ${{ matrix.repo.ref }}
         fetch-depth: 1
+    - name: Checkout renku-actions repo
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 1
+        path: .actions-repo
     - name: Update actions version
-      uses: SwissDataScienceCenter/renku-actions/update-renku-actions@master
+      uses: ./.actions-repo/update-renku-actions
     - name: Submit PR
       uses: peter-evans/create-pull-request@v3
       with:

--- a/.github/workflows/update-on-new-release.yaml
+++ b/.github/workflows/update-on-new-release.yaml
@@ -20,7 +20,7 @@ jobs:
           - name: SwissDataScienceCenter/renku-gateway
             ref: master
           - name: SwissDataScienceCenter/renku-graph
-            ref: master
+            ref: development
     runs-on: ubuntu-latest
     steps:
     - name: Get release tag
@@ -32,7 +32,7 @@ jobs:
         ref: ${{ matrix.repo.ref }}
         fetch-depth: 1
     - name: Update actions version
-      uses: SwissDataScienceCenter/renku-actions/update-renku-actions@v0.4.0
+      uses: SwissDataScienceCenter/renku-actions/update-renku-actions@master
     - name: Submit PR
       uses: peter-evans/create-pull-request@v3
       with:


### PR DESCRIPTION
renku-graph uses `development` as their main branch. It used to be master. This way the automated PRs that update the action version will work.