### PR TITLE
chore: increase test timeout

### DIFF
--- a/test-renku/action.yml
+++ b/test-renku/action.yml
@@ -17,7 +17,7 @@ inputs:
   test-timeout-mins:
     description: "The timeout in mins to wait for the helm tests to complete."
     required: false
-    default: "60"
+    default: "80"
   ci-renku-values:
     description: "The helm values file contents used to deploy renku, used here only to extract the S3 bucket credentials."
     required: true


### PR DESCRIPTION
A few of our projects override the default and set it to 80... so why not make it the default. 