### PR TITLE
chore: bump base image for deploy to fix issue with helm number formatting

### DIFF
--- a/deploy-renku/Dockerfile
+++ b/deploy-renku/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine/k8s:1.16.8
+FROM alpine/k8s:1.21.12
 
 # install dependencies
 RUN apk add python3 docker jq && \


### PR DESCRIPTION
Helm <3.8 has an issue where large numbers like `1073741824` get turned into scientific notation like `1.073741824e+09` which can break things further down the line (e.g. converting an env variable back to int).

Bumping the base image updates helm to version 3.9.0, which does not have this issue.