### PR TITLE
fix: do not add submodule when updating actions

### DIFF
--- a/.github/workflows/update-on-new-release.yaml
+++ b/.github/workflows/update-on-new-release.yaml
@@ -14,7 +14,7 @@ jobs:
           - name: SwissDataScienceCenter/renku-notebooks
             ref: master
           - name: SwissDataScienceCenter/renku-python
-            ref: master
+            ref: develop
           - name: SwissDataScienceCenter/renku-ui
             ref: master
           - name: SwissDataScienceCenter/renku-gateway
@@ -38,6 +38,8 @@ jobs:
         path: .actions-repo
     - name: Update actions version
       uses: ./.actions-repo/update-renku-actions
+    - name: Remove renku-actions repo
+      run: rm -rf ./.actions-repo
     - name: Submit PR
       uses: peter-evans/create-pull-request@v3
       with:


### PR DESCRIPTION
Without this fix the renku actions repo will be committed as a submodule in every other repo where it updates the version.

This should also cleanup/remove committed renku-actions submodules from older versions.

In addition the default branch for renku python is develop. So PRs for renku actions updates should be directed there.