### PR TITLE
chore(rollout-renku-version): upgrade yq to 4.27.5

### DIFF
--- a/rollout-renku-version/Dockerfile
+++ b/rollout-renku-version/Dockerfile
@@ -3,7 +3,7 @@ FROM python:3.7-alpine3.10
 # install dependencies
 RUN apk add --no-cache git bash && \
     apk add --no-cache --virtual .build-deps gcc g++ make && \
-    wget -O /usr/bin/yq "https://github.com/mikefarah/yq/releases/download/3.1.1/yq_linux_amd64" && \
+    wget -O /usr/bin/yq "https://github.com/mikefarah/yq/releases/download/v4.27.5/yq_linux_amd64" && \
     chmod a+x /usr/bin/yq && \
     apk del .build-deps
 

--- a/rollout-renku-version/rollout-renku-deployment.sh
+++ b/rollout-renku-version/rollout-renku-deployment.sh
@@ -44,7 +44,7 @@ do
     # update renku version and push
     git checkout -b auto-update/${CHART_NAME}-${CHART_VERSION}-${cluster} ${UPSTREAM_BRANCH}
 
-    yq w -i $cluster_dir/main/charts/renku.yaml "spec.chart.spec.version" $CHART_VERSION
+    yq -i '.spec.chart.spec.version = "$CHART_VERSION"' $cluster_dir/main/charts/renku.yaml
     sed -i "/Renku version/c\            ### Renku version $CHART_VERSION ($DATE)" $cluster_dir/main/charts/renku.yaml
     sed -i "/Release Notes/c\            See the [Release Notes](https://github.com/${GITHUB_REPOSITORY}/releases/tag/$CHART_VERSION)" $cluster_dir/main/charts/renku.yaml
 


### PR DESCRIPTION
This new version of `yq` does not change the existing
formatting of the YAML file it edits.
