### PR TITLE
remove renku-python from update-on-release-action

### DIFF
--- a/.github/workflows/update-on-new-release.yaml
+++ b/.github/workflows/update-on-new-release.yaml
@@ -13,8 +13,6 @@ jobs:
             ref: master
           - name: SwissDataScienceCenter/renku-notebooks
             ref: master
-          - name: SwissDataScienceCenter/renku-python
-            ref: develop
           - name: SwissDataScienceCenter/renku-ui
             ref: master
           - name: SwissDataScienceCenter/renku-gateway


### PR DESCRIPTION
Dependabot already takes care of this, see e.g. https://github.com/SwissDataScienceCenter/renku-python/pull/3156