### PR TITLE
fix: remove unused input markes as required

### DIFF
--- a/test-renku/action.yml
+++ b/test-renku/action.yml
@@ -28,9 +28,6 @@ inputs:
   s3-results-secret-key:
     description: Secret key to the S3 bucket where the tests artifacts have been stored
     required: true
-  s3-results-artifacts-path:
-    description: Path within the S3 bucket where the tests artifacts have been stored
-    required: true
   test-timeout-mins:
     description: "The timeout in mins to wait for the helm tests to complete."
     required: false


### PR DESCRIPTION
`s3-results-artifacts-path` wasn't used anywhere (and I'm fed up with the linter accusing me of invoking this action without the necessary params :stuck_out_tongue: )