### PR TITLE
chore: update YQ everywhere and deploy-renku wants split values files.

### DIFF
--- a/deploy-renku/Dockerfile
+++ b/deploy-renku/Dockerfile
@@ -1,10 +1,8 @@
-FROM alpine/k8s:1.23.17
+FROM alpine/k8s:1.24.16
 
 # install dependencies
 COPY requirements.txt /
-RUN apk add --no-cache python3 docker jq && \
-    wget -O /usr/bin/yq "https://github.com/mikefarah/yq/releases/download/3.1.1/yq_linux_amd64" && \
-    chmod a+x /usr/bin/yq && \
+RUN apk add python3 docker jq yq && \
     pip3 install -r /requirements.txt
 
 COPY deploy-dev-renku.py entrypoint.sh /

--- a/publish-chartpress-images/Dockerfile
+++ b/publish-chartpress-images/Dockerfile
@@ -1,10 +1,7 @@
 FROM docker:24.0.6-git
 
 # install dependencies
-# Note: Chartpress 0.7.0 is the latest version compatible until https://github.com/jupyterhub/chartpress/issues/118 is fixed
-RUN apk add python3 py-pip py3-ruamel.yaml && \
-    wget -O /usr/bin/yq "https://github.com/mikefarah/yq/releases/download/3.1.1/yq_linux_amd64" && \
-    chmod 0755 /usr/bin/yq && \
+RUN apk add python3 py-pip && \
     pip3 install -U pip chartpress==2.1.0 && \
     wget -O /tmp/helm.tar.gz "https://get.helm.sh/helm-v3.5.2-linux-amd64.tar.gz" && \
     tar -xf /tmp/helm.tar.gz --strip-components=1 -C /usr/bin/ && \

--- a/rollout-renku-version/Dockerfile
+++ b/rollout-renku-version/Dockerfile
@@ -1,11 +1,8 @@
-FROM python:3.7-alpine3.10
+FROM alpine:3.18
 
 # install dependencies
-RUN apk add --no-cache git bash && \
-    apk add --no-cache --virtual .build-deps gcc g++ make && \
-    wget -O /usr/bin/yq "https://github.com/mikefarah/yq/releases/download/v4.27.5/yq_linux_amd64" && \
-    chmod a+x /usr/bin/yq && \
-    apk del .build-deps
+RUN apk update && \
+    apk add --no-cache git bash yq
 
 COPY rollout-renku-deployment.sh /
 RUN chmod +x /rollout-renku-deployment.sh

--- a/rollout-renku-version/README.md
+++ b/rollout-renku-version/README.md
@@ -1,6 +1,6 @@
 # Action for updating component version
 
-This is a docker action that will update the Renku version (rollout) in the deployments managed by terraform.
+This is a docker action that will update the Renku version (rollout) in the deployments managed by Terraform.
 
 ## Sample usage
 

--- a/rollout-renku-version/rollout-renku-deployment.sh
+++ b/rollout-renku-version/rollout-renku-deployment.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -xe
+set -e
 
 if [ -z "$GITHUB_TOKEN" ]
 then
@@ -47,7 +47,7 @@ do
     # update renku version and push
     git checkout -b auto-update/${CHART_NAME}-${CHART_VERSION}-${cluster} ${UPSTREAM_BRANCH}
 
-    yq -i '.spec.chart.spec.version = strenv(CHART_VERSION)' $cluster_dir/main/charts/renku.yaml
+    yq eval --inplace '.spec.chart.spec.version = strenv(CHART_VERSION)' $cluster_dir/main/charts/renku.yaml
     sed -i "/Renku version/c\            ### Renku version $CHART_VERSION ($DATE)" $cluster_dir/main/charts/renku.yaml
     sed -i "/Release Notes/c\            See the [Release Notes](https://github.com/${GITHUB_REPOSITORY}/releases/tag/$CHART_VERSION)" $cluster_dir/main/charts/renku.yaml
 

--- a/update-component-version/Dockerfile
+++ b/update-component-version/Dockerfile
@@ -1,12 +1,11 @@
-FROM python:3.7-alpine3.10
+FROM python:3.9-alpine3.18
 
 # install dependencies
-RUN apk add --no-cache git bash && \
-    apk add --no-cache --virtual .build-deps gcc g++ make && \
-    wget -O /usr/bin/yq "https://github.com/mikefarah/yq/releases/download/3.1.1/yq_linux_amd64" && \
-    chmod a+x /usr/bin/yq && \
-    pip install -U pip chartpress==2.1.0 six==1.16.0 && \
-    apk del .build-deps
+RUN apk add --no-cache git bash yq && \
+    pip install -U pip \
+    chartpress==2.1.0 \
+    'ruamel.yaml<0.17.10' \
+    'ruamel.yaml.clib<0.2.4'
 
 COPY update-upstream.sh /
 ENTRYPOINT [ "/update-upstream.sh" ]

--- a/update-renku-actions/Dockerfile
+++ b/update-renku-actions/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.15
+FROM alpine:3.18
 
 RUN apk add --no-cache yq
 COPY entrypoint.sh /


### PR DESCRIPTION
- deploy-renku now expects two files for the values of the Helm chart to deploy:
one is the secrets that are stored in GH organization, the other is a file passed
to the action, meant to be in the Renku repository itself.

- YQ has been updated to version 4.x everywhere and the commands fixed according
to the need of the new version

- The base Docker image have also been updated

- YQ is now installed in all actions through the Alpine package directly
