### PR TITLE
Improve deploy action

### DIFF
--- a/deploy-renku/deploy-dev-renku.py
+++ b/deploy-renku/deploy-dev-renku.py
@@ -241,6 +241,8 @@ if __name__ == "__main__":
         namespace,
         "--timeout",
         "20m",
+        "--wait",
+        "--wait-for-jobs",
     ]
 
     if os.getenv("TEST_ARTIFACTS_PATH"):

--- a/test-renku/action.yml
+++ b/test-renku/action.yml
@@ -28,9 +28,6 @@ inputs:
   s3-results-secret-key:
     description: Secret key to the S3 bucket where the tests artifacts have been stored
     required: true
-  s3-results-artifacts-path:
-    description: Path within the S3 bucket where the tests artifacts have been stored
-    required: true
   test-timeout-mins:
     description: "The timeout in mins to wait for the helm tests to complete."
     required: false


### PR DESCRIPTION
A couple of changes to the deploy action:

* Add `--wait` and `--wait-for-jobs` to the `helm upgrade` command to prevent marking the environment ready too soon and running tests early (ref: https://helm.sh/docs/helm/helm_upgrade/#options )