### PR TITLE
chore: remove the #persist flag

### DIFF
--- a/check-pr-description/README.md
+++ b/check-pr-description/README.md
@@ -65,19 +65,6 @@ The `#cypress` string will set to true the otherwise falsy variable named `test-
 
 This can be used to make decisions about running the cypress acceptance tests.
 
-### Persisting a deployment after the tests are complete
-
-The `#persist` string will set the `persist` flag to `true` which is `false` by default.
-The `persist` parameter in the action output can then be used to signal to the `test-renku`
-action that the Renku deployment should not be deleted (i.e. it should perisist) after the
-tests complete.
-
-For example:
-
-```
-/deploy renku-ui=0.11.9 #persist
-```
-
 ## Procedures for renku platform PRs
 
 The process for using this action in renku PR reviews is outlined here:

--- a/check-pr-description/README.md
+++ b/check-pr-description/README.md
@@ -49,21 +49,11 @@ the `extra-values` option.
 ### Skipping tests
 
 The `#notest` string will falsify the otherwise truthy variable named `test-enabled`,
-for example
+skipping all the acceptance tests.
 
 ```
 /deploy renku-ui=0.11.9 #notest
 ```
-
-### Running Cypress acceptance tests
-
-The `#cypress` string will set to true the otherwise falsy variable named `test-cypress-enabled`, for example
-
-```
-/deploy #cypress
-```
-
-This can be used to make decisions about running the cypress acceptance tests.
 
 ## Procedures for renku platform PRs
 

--- a/check-pr-description/action.yaml
+++ b/check-pr-description/action.yaml
@@ -35,9 +35,6 @@ outputs:
   test-enabled:
     description: whether the selenium tests should run or not
     value: ${{ steps.check-string.outputs.test-enabled }}
-  test-cypress-enabled:
-    description: whether the cypress tests should run or not
-    value: ${{ steps.check-string.outputs.test-cypress-enabled }}
 runs:
   using: "composite"
   steps:
@@ -49,7 +46,6 @@ runs:
         echo "pr-contains-string=$pr_contains_string" >> $GITHUB_OUTPUT
         echo "String found: $pr_contains_string"
         test_enabled=true
-        cypress_enabled=false
         if [ "$pr_contains_string" = true ] ; then
           command=$(echo $pr_text | jq -r 'split("${{ inputs.string }} ") | last | split("\r\n") | first')
           if [[ $command != *"${{ inputs.string }}"* ]]; then
@@ -88,10 +84,6 @@ runs:
             if [[ $command =~ $match ]]; then
               test_enabled=false
             fi
-            match="#cypress"
-            if [[ $command =~ $match ]]; then
-              cypress_enabled=true
-            fi
             match="extra-values=(\S*)"
             if [[ $command =~ $match ]]; then
               echo "extra values: ${BASH_REMATCH[1]}"
@@ -103,6 +95,4 @@ runs:
         fi
         echo "Test enabled: $test_enabled"
         echo "test-enabled=${test_enabled}" >> $GITHUB_OUTPUT
-        echo "Cypress enabled: $cypress_enabled"
-        echo "test-cypress-enabled=${cypress_enabled}" >> $GITHUB_OUTPUT
       shell: bash

--- a/check-pr-description/action.yaml
+++ b/check-pr-description/action.yaml
@@ -38,9 +38,6 @@ outputs:
   test-cypress-enabled:
     description: whether the cypress tests should run or not
     value: ${{ steps.check-string.outputs.test-cypress-enabled }}
-  persist:
-    description: whether the CI deployment should be kept after the acceptance tests complete
-    value: ${{ steps.check-string.outputs.persist }}
 runs:
   using: "composite"
   steps:
@@ -53,7 +50,6 @@ runs:
         echo "String found: $pr_contains_string"
         test_enabled=true
         cypress_enabled=false
-        persist=false
         if [ "$pr_contains_string" = true ] ; then
           command=$(echo $pr_text | jq -r 'split("${{ inputs.string }} ") | last | split("\r\n") | first')
           if [[ $command != *"${{ inputs.string }}"* ]]; then
@@ -96,10 +92,6 @@ runs:
             if [[ $command =~ $match ]]; then
               cypress_enabled=true
             fi
-            match="#persist"
-            if [[ $command =~ $match ]]; then
-              persist=true
-            fi
             match="extra-values=(\S*)"
             if [[ $command =~ $match ]]; then
               echo "extra values: ${BASH_REMATCH[1]}"
@@ -113,6 +105,4 @@ runs:
         echo "test-enabled=${test_enabled}" >> $GITHUB_OUTPUT
         echo "Cypress enabled: $cypress_enabled"
         echo "test-cypress-enabled=${cypress_enabled}" >> $GITHUB_OUTPUT
-        echo "Persist CI deployment after tests: $persist"
-        echo "persist=${persist}" >> $GITHUB_OUTPUT
       shell: bash

--- a/test-renku-cypress/README.md
+++ b/test-renku-cypress/README.md
@@ -28,7 +28,13 @@ jobs:
       fail-fast: false
       max-parallel: 1
       matrix:
-        tests: [publicProject, updateProjects, useSession]
+        tests:
+          - publicProject
+          - privateProject
+          - updateProjects
+          - testDatasets
+          - useSession
+          - checkWorkflows
     steps:
       - name: Extract Renku repository reference
         run: echo "RENKU_REFERENCE=`echo '${{ needs.check-deploy.outputs.renku }}' | cut -d'@' -f2`" >> $GITHUB_ENV

--- a/test-renku-cypress/README.md
+++ b/test-renku-cypress/README.md
@@ -39,18 +39,3 @@ jobs:
           renku-release: renku-ci-ui-${{ github.event.number }}
           test-user-password: ${{ secrets.RENKU_BOT_DEV_PASSWORD }}
 ```
-
-# Interaction with Selenium-based acceptance tests
-
-This action **does not** tear down the deployment, but the `test-renku` action to run the Selenium-based tests does, and some care needs to be taken when running the Cypress tests without running the Selenium tests.
-
-Specifically, it is necessary to persist the deployment using the `#persist` flag.
-
-```
-/deploy #persist
-```
-
-Mind that not using the `#persist` flag will result in the deployment being torn down after the Selenium tests; this _should_ work when both tests run in parallel since Selenium tests are generally slower, but this is not guarantend.
-
-Also, re-running only Cypress tests would not work since the deployment will not be available anymore.
-

--- a/test-renku-cypress/action.yml
+++ b/test-renku-cypress/action.yml
@@ -39,10 +39,6 @@ inputs:
     description: "The working directory for the Cypress tests"
     required: false
     default: "renku/cypress-tests"
-  test-timeout-mins:
-    description: "The timeout in mins to wait for the helm tests to complete."
-    required: false
-    default: "60"
   test-user-email:
     description: "The email address of the test user"
     required: false
@@ -106,6 +102,3 @@ runs:
         name: Cypress acceptance tests - videos
         path: ${{ inputs.settings-working-directory }}/cypress/videos
         retention-days: 3
-
-# TODO: add the logic to tear down the renku deployment once selenium tests are phased out
-# ? - name: "Cleanup CI deployment after test if persist flag set to false"

--- a/test-renku/README.md
+++ b/test-renku/README.md
@@ -4,7 +4,6 @@ This is a composite action that:
 - sets up helm
 - run the helm tests
 - downloads test results from S3
-- optionally cleans up the CI deployment at the end
 
 ## Example use
 ```yaml
@@ -14,7 +13,6 @@ steps:
     renkubot-kubeconfig: ${{ secrets.RENKUBOT_DEV_KUBECONFIG }}
     renku-release: ci-renku-${{ github.event.number }}
     gitlab-token: ${{ secrets.DEV_GITLAB_TOKEN }}
-    persist: "${{ needs.check-deploy.outputs.persist }}"
     ci-renku-values: ${{ secrets.CI_RENKU_VALUES }}
 ```
 
@@ -25,6 +23,5 @@ steps:
 | renkubot-kubeconfig  | helm-chart/ | Yes      |
 | renku-release        | None        | Yes      |
 | gitlab-token         | None        | Yes      |
-| persist              | false       | No       |
 | test-timeout-mins    | 60          | No       |
 | ci-renku-values      | None        | Yes      |

--- a/test-renku/action.yml
+++ b/test-renku/action.yml
@@ -10,10 +10,6 @@ inputs:
   gitlab-token:
     description: "A gitlab token used for the cleanup of application in Gitlab."
     required: true
-  persist:
-    description: "Whether the CI deployment should be kept after the tests finish or not."
-    required: false
-    default: "false"
   s3-results-host:
     default: os.zhdk.cloud.switch.ch
     description: S3 host where the tests artifacts have been stored
@@ -48,7 +44,7 @@ runs:
         TEST_TIMEOUT_MINS: ${{ inputs.test-timeout-mins }}
     - name: Download artifact for packaging on failure
       if: failure()
-      uses: SwissDataScienceCenter/renku-actions/download-test-artifacts@v1.0.0
+      uses: SwissDataScienceCenter/renku-actions/download-test-artifacts@v1.5.2
       with:
         s3-results-host: ${{ inputs.s3-results-host }}
         s3-results-bucket: ${{ inputs.s3-results-bucket }}
@@ -61,12 +57,4 @@ runs:
       with:
         name: acceptance-test-artifacts
         path: ${{ github.workspace }}/test-artifacts/
-    - name: "Cleanup CI deployment after test if persist flag set to false"
-      uses: SwissDataScienceCenter/renku-actions/cleanup-renku-ci-deployments@v1.0.0
-      if: ${{ always() && inputs.persist == 'false' }}
-      env:
-        RENKUBOT_KUBECONFIG: ${{ inputs.kubeconfig }}
-        HELM_RELEASE_REGEX: "^${{ inputs.renku-release }}$"
-        MAX_AGE_SECONDS: "0"
-        GITLAB_TOKEN: ${{ inputs.gitlab-token }}
-        DELETE_NAMESPACE: "false"
+


### PR DESCRIPTION
With recent updates on the acceptance tests, we _always_ use the `#persist` flag. We can get rid of it.

I suggest implementing a more aggressive strategy to regularly cull CI deployments that have been running for some time without changes (3 days?)