### PR TITLE
redirect subprocess call stdout/err to parent

### DIFF
--- a/deploy-renku/deploy-dev-renku.py
+++ b/deploy-renku/deploy-dev-renku.py
@@ -265,5 +265,6 @@ if __name__ == "__main__":
         stdout=sys.stdout,
         stderr=sys.stderr
     )
-
+    sys.stdout.flush()
+    sys.stderr.flush()
     tempdir_.cleanup()

--- a/deploy-renku/deploy-dev-renku.py
+++ b/deploy-renku/deploy-dev-renku.py
@@ -18,7 +18,7 @@ import tempfile
 import urllib.request
 import yaml
 from pathlib import Path
-from subprocess import run
+from subprocess import run, check_call
 
 import json_merge_patch
 from packaging.version import Version

--- a/deploy-renku/deploy-dev-renku.py
+++ b/deploy-renku/deploy-dev-renku.py
@@ -18,7 +18,7 @@ import tempfile
 import urllib.request
 import yaml
 from pathlib import Path
-from subprocess import check_call
+from subprocess import run
 
 import json_merge_patch
 from packaging.version import Version
@@ -259,12 +259,15 @@ if __name__ == "__main__":
         helm_command += ["--set", args.extra_values]
 
     # deploy the main chart
-    check_call(
-        helm_command,
-        cwd=renku_dir / "helm-chart",
-        stdout=sys.stdout,
-        stderr=sys.stderr
-    )
-    sys.stdout.flush()
-    sys.stderr.flush()
-    tempdir_.cleanup()
+    try:
+        run(
+            helm_command,
+            cwd=renku_dir / "helm-chart",
+            stdout=sys.stdout,
+            stderr=sys.stderr,
+            check=True
+        )
+    finally:
+        sys.stdout.flush()
+        sys.stderr.flush()
+        tempdir_.cleanup()

--- a/deploy-renku/deploy-dev-renku.py
+++ b/deploy-renku/deploy-dev-renku.py
@@ -13,6 +13,7 @@ import json
 import os
 import pprint
 import re
+import sys
 import tempfile
 import urllib.request
 import yaml
@@ -261,6 +262,8 @@ if __name__ == "__main__":
     check_call(
         helm_command,
         cwd=renku_dir / "helm-chart",
+        stdout=sys.stdout,
+        stderr=sys.stderr
     )
 
     tempdir_.cleanup()


### PR DESCRIPTION
This should prevent the deploy script from swallowing helm error messages.