### PR TITLE
fix: trust local git repo when running chartpress

### DIFF
--- a/publish-chartpress-images/publish-images.sh
+++ b/publish-chartpress-images/publish-images.sh
@@ -16,6 +16,8 @@ fi
 # log in to docker
 echo ${DOCKER_PASSWORD} | docker login -u ${DOCKER_USERNAME} --password-stdin
 
+# if this is not run then git complains that the repo directory is untrusted and fails
+git config --global --add safe.directory $PWD
 # build and push the chart and images
 cd $CHARTPRESS_SPEC_DIR
 chartpress --push $CHART_TAG $IMAGE_PREFIX


### PR DESCRIPTION
This error shows up when we try to publish images with chartpress:
```
+ cd .
+ chartpress --push --tag 1.19.1
fatal: detected dubious ownership in repository at '/github/workspace'
To add an exception for this directory, call:

	git config --global --add safe.directory /github/workspace
Leaving helm-chart/renku-notebooks/Chart.yaml version unchanged: 1.19.1
```

To avoid this, we change the config in the action to trust the repo. As I see it this happens because the github checkout step may run as a different user than the chartpress step.

I looked at this article for help:
https://medium.com/@janloo/github-actions-detected-dubious-ownership-in-repository-at-github-workspace-how-to-fix-b9cc127d4c04