### PR TITLE
feat: add new callback for new gateway

### DIFF
--- a/deploy-renku/entrypoint.sh
+++ b/deploy-renku/entrypoint.sh
@@ -20,7 +20,7 @@ if test -n "$GITLAB_TOKEN" ; then
   gitlab_app=$(curl -s -X POST ${GITLAB_URL}/api/v4/applications \
                         -H "private-token: $GITLAB_TOKEN" \
                         --data "name=${RENKU_RELEASE}" \
-                        --data "redirect_uri=https://${RENKU_RELEASE}.dev.renku.ch/auth/realms/Renku/broker/dev-renku/endpoint https://${RENKU_RELEASE}.dev.renku.ch/api/auth/gitlab/token" \
+                        --data "redirect_uri=https://${RENKU_RELEASE}.dev.renku.ch/auth/realms/Renku/broker/dev-renku/endpoint https://${RENKU_RELEASE}.dev.renku.ch/api/auth/gitlab/token https://${RENKU_RELEASE}.dev.renku.ch/api/auth/callback" \
                         --data "scopes=api read_user read_repository read_registry openid")
   APP_ID=$(echo $gitlab_app | jq -r '.application_id')
   APP_SECRET=$(echo $gitlab_app | jq -r '.secret')


### PR DESCRIPTION
The gateway has a callback on a different URL, so we need to register this in the gitlab application for CI deployments.

The keycloak app does not need changes because it accepts `*` callback urls. And the callback in gitlab is registered as anything that is part of the renku base URL.