### PR TITLE
chore: Update Helm in publish-chart to latest version.

### DIFF
--- a/publish-chart/Dockerfile
+++ b/publish-chart/Dockerfile
@@ -5,7 +5,7 @@ RUN apk add python3 py-pip py3-ruamel.yaml && \
     wget -O /usr/bin/yq "https://github.com/mikefarah/yq/releases/download/3.1.1/yq_linux_amd64" && \
     chmod 0755 /usr/bin/yq && \
     pip3 install -U pip chartpress==2.1.0 && \
-    wget -O /tmp/helm.tar.gz "https://get.helm.sh/helm-v3.5.2-linux-amd64.tar.gz" && \
+    wget -O /tmp/helm.tar.gz "https://get.helm.sh/helm-v3.14.2-linux-amd64.tar.gz" && \
     tar -xf /tmp/helm.tar.gz --strip-components=1 -C /usr/bin/ && \
     chmod 0755 /usr/bin/helm
 


### PR DESCRIPTION
This is required to correctly handle OCI Helm repositories.
