### PR TITLE
chore: update node and cypress action

### DIFF
--- a/test-renku-cypress/action.yml
+++ b/test-renku-cypress/action.yml
@@ -68,13 +68,13 @@ runs:
         repository: ${{ inputs.renku-repository }}
         path: ${{ inputs.renku-path }}
         ref: ${{ inputs.renku-reference }}
-    - uses: actions/setup-node@v3
-      name: Setup Node v18
+    - uses: actions/setup-node@v4
+      name: Setup Node LTS
       with:
-        node-version: 18
+        node-version: lts
         cache: npm
         cache-dependency-path: ${{ inputs.settings-working-directory }}
-    - uses: cypress-io/github-action@v5
+    - uses: cypress-io/github-action@v6
       name: "Verify infrastructure and run the target Cypress test"
       id: cypress-acceptance-tests
       env:

--- a/test-renku-cypress/action.yml
+++ b/test-renku-cypress/action.yml
@@ -71,7 +71,7 @@ runs:
     - uses: actions/setup-node@v4
       name: Setup Node LTS
       with:
-        node-version: lts
+        node-version: lts/*
         cache: npm
         cache-dependency-path: ${{ inputs.settings-working-directory }}
     - uses: cypress-io/github-action@v6

--- a/test-renku-cypress/action.yml
+++ b/test-renku-cypress/action.yml
@@ -69,9 +69,9 @@ runs:
         path: ${{ inputs.renku-path }}
         ref: ${{ inputs.renku-reference }}
     - uses: actions/setup-node@v4
-      name: Setup Node LTS
+      name: Setup Node v20
       with:
-        node-version: lts/*
+        node-version: 20
         cache: npm
         cache-dependency-path: ${{ inputs.settings-working-directory }}
     - uses: cypress-io/github-action@v6


### PR DESCRIPTION
It is better to always run with the LTS node version IMO.