### PR TITLE
fix: correct pip3 invocation for requests<2.32.0

### DIFF
--- a/publish-chart/Dockerfile
+++ b/publish-chart/Dockerfile
@@ -5,7 +5,7 @@ RUN apk add python3 py-pip py3-ruamel.yaml && \
     wget -O /usr/bin/yq "https://github.com/mikefarah/yq/releases/download/3.1.1/yq_linux_amd64" && \
     chmod 0755 /usr/bin/yq && \
 # requests 2.32.0 has a bug with not allowing docker+http protocol, see requests/issues/6707
-    pip3 install -U pip chartpress==2.1.0 requests<2.32.0 && \
+    pip3 install -U pip chartpress==2.1.0 "requests<2.32.0" && \
     wget -O /tmp/helm.tar.gz "https://get.helm.sh/helm-v3.14.2-linux-amd64.tar.gz" && \
     tar -xf /tmp/helm.tar.gz --strip-components=1 -C /usr/bin/ && \
     chmod 0755 /usr/bin/helm

--- a/publish-chartpress-images/Dockerfile
+++ b/publish-chartpress-images/Dockerfile
@@ -6,7 +6,7 @@ RUN apk add python3 py-pip py3-ruamel.yaml && \
     wget -O /usr/bin/yq "https://github.com/mikefarah/yq/releases/download/3.1.1/yq_linux_amd64" && \
     chmod 0755 /usr/bin/yq && \
 # requests 2.32.0 has a bug with not allowing docker+http protocol, see requests/issues/6707
-    pip3 install -U pip chartpress==2.1.0 requests<2.32.0 && \
+    pip3 install -U pip chartpress==2.1.0 "requests<2.32.0" && \
     wget -O /tmp/helm.tar.gz "https://get.helm.sh/helm-v3.5.2-linux-amd64.tar.gz" && \
     tar -xf /tmp/helm.tar.gz --strip-components=1 -C /usr/bin/ && \
     chmod 0755 /usr/bin/helm

--- a/update-component-version/Dockerfile
+++ b/update-component-version/Dockerfile
@@ -6,7 +6,7 @@ RUN apk add --no-cache git bash && \
     wget -O /usr/bin/yq "https://github.com/mikefarah/yq/releases/download/3.1.1/yq_linux_amd64" && \
     chmod a+x /usr/bin/yq && \
 # requests 2.32.0 has a bug with not allowing docker+http protocol, see requests/issues/6707
-    pip install -U pip chartpress==2.1.0 six==1.16.0 requests<2.32.0 && \
+    pip install -U pip chartpress==2.1.0 six==1.16.0 "requests<2.32.0" && \
     apk del .build-deps && \
     cd /usr/bin && \
     wget https://github.com/google/yamlfmt/releases/download/v0.10.0/yamlfmt_0.10.0_Linux_x86_64.tar.gz && \


### PR DESCRIPTION
Fixes `publish-chart`, `publish-chartpress-images` and `update-component-version` which were broken by #84.

Example: https://github.com/SwissDataScienceCenter/renku-notebooks/actions/runs/9192250296/job/25282800881#step:2:36.