### PR TITLE
fix: check pr description action

### DIFF
--- a/check-pr-description/action.yaml
+++ b/check-pr-description/action.yaml
@@ -114,6 +114,7 @@ runs:
             if [[ $command =~ $match ]]; then
               echo "secrets-storage reference: ${BASH_REMATCH[1]}"
               echo "secrets-storage=@${BASH_REMATCH[1]}" >> $GITHUB_OUTPUT
+            fi
             match="renku-search=(\S*)"
             if [[ $command =~ $match ]]; then
               echo "renku-search reference: ${BASH_REMATCH[1]}"


### PR DESCRIPTION
Resolving conflicts in the new actions release caused this small issue.

It took me trial and error to find the missing `fi`.