### PR TITLE
fix: update the version of the upload-artifact action

### DIFF
--- a/test-renku/action.yml
+++ b/test-renku/action.yml
@@ -53,8 +53,7 @@ runs:
         s3-results-artifacts-path: "tests-artifacts-${{ github.sha }}"
     - name: Upload screenshots on failure
       if: failure()
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v4
       with:
         name: acceptance-test-artifacts
         path: ${{ github.workspace }}/test-artifacts/
-


### PR DESCRIPTION
The upload-artifact version used by the selenium tests was out of date, and github was refusing to run the action as a result. This updates to the current version of [upload-artifact](https://github.com/actions/upload-artifact).

The action was tested in https://github.com/SwissDataScienceCenter/renku-ui/actions/runs/10808535902/job/29982169525?pr=3275