### PR TITLE
feat: add option to push latest image

### DIFF
--- a/publish-chartpress-images/README.md
+++ b/publish-chartpress-images/README.md
@@ -29,3 +29,7 @@ You can set these environment variables:
 | DOCKER_USERNAME      | None        | Yes      |
 | IMAGE_PREFIX         | None        | No       |
 | CHARTPRESS_SPEC_DIR  | .           | No       |
+| PUSH_LATEST          | None        | No       |
+
+Note: setting the `PUSH_LATEST` variable to any non-zero value will trigger the publishing of
+the images with the `latest` tag.

--- a/publish-chartpress-images/publish-images.sh
+++ b/publish-chartpress-images/publish-images.sh
@@ -21,3 +21,8 @@ git config --global --add safe.directory $PWD
 # build and push the chart and images
 cd $CHARTPRESS_SPEC_DIR
 chartpress --push $CHART_TAG $IMAGE_PREFIX
+
+if [ ! -z "$PUSH_LATEST" ]; then
+    echo "Pushing images with 'latest' tags"
+    chartpress --push --tag latest $IMAGE_PREFIX
+fi


### PR DESCRIPTION
Changes the publish-chartpress-images action to optionally push images tagged with 'latest'.