### PR TITLE
chore: bump actions/upload-artifact@v4

### DIFF
--- a/test-renku-cypress/action.yml
+++ b/test-renku-cypress/action.yml
@@ -90,13 +90,13 @@ runs:
           ${{ inputs.e2e-folder }}${{ inputs.e2e-infrastructure-check }}${{ inputs.e2e-suffix }}
           ${{ inputs.e2e-folder }}${{ inputs.e2e-target }}${{ inputs.e2e-suffix }}
         working-directory: ${{ inputs.settings-working-directory }}
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       if: failure()
       with:
         name: Cypress acceptance tests - screenshots
         path: ${{ inputs.settings-working-directory }}/cypress/screenshots
         retention-days: 7
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       if: failure()
       with:
         name: Cypress acceptance tests - videos


### PR DESCRIPTION
v3 is deprecated
https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/

![Screenshot_20250130_150945](https://github.com/user-attachments/assets/119d6497-3e1c-4a71-9989-8935c01e61bb)
