### PR TITLE
feat: Use the base value file for CI deployment from the Renku repo

### DIFF
--- a/deploy-renku/Dockerfile
+++ b/deploy-renku/Dockerfile
@@ -3,7 +3,7 @@ FROM alpine/k8s:1.23.17
 # install dependencies
 COPY requirements.txt /
 RUN apk add --no-cache python3 docker jq && \
-    wget -O /usr/bin/yq "https://github.com/mikefarah/yq/releases/download/3.1.1/yq_linux_amd64" && \
+    wget -O /usr/bin/yq "https://github.com/mikefarah/yq/releases/download/v4.45.1/yq_linux_amd64" && \
     chmod a+x /usr/bin/yq && \
     pip3 install -r /requirements.txt
 


### PR DESCRIPTION
This prepares the action to work with a base values file that comes directly from the Renku repository itself instead of the Github secrets.

I have tested this action here: https://github.com/SwissDataScienceCenter/renku/pull/3921