### PR TITLE
feat: fail cypress tests when then spec is missing

### DIFF
--- a/test-renku-cypress/README.md
+++ b/test-renku-cypress/README.md
@@ -14,7 +14,6 @@ Mind that you need to provide the e2e file name; the action is structured to run
 ```yaml
     strategy:
       fail-fast: false
-      max-parallel: 1
       matrix:
         tests: [publicProject, updateProjects, useSession]
 ```
@@ -26,7 +25,6 @@ jobs:
   cypress-acceptance-tests:
     strategy:
       fail-fast: false
-      max-parallel: 1
       matrix:
         tests:
           - publicProject

--- a/test-renku-cypress/action.yml
+++ b/test-renku-cypress/action.yml
@@ -73,7 +73,7 @@ runs:
       shell: bash
       run: |
         echo "Looking for tests matching '${{ inputs.e2e-target }}'"
-        match=$(find "${{ inputs.e2e-folder }}" -type f -name "${{ inputs.e2e-target }}${{ inputs.e2e-suffix }}" | wc -l)
+        match=$(find "${{ inputs.settings-working-directory }}/${{ inputs.e2e-folder }}" -type f -name "${{ inputs.e2e-target }}${{ inputs.e2e-suffix }}" | wc -l)
         if [ "$match" -eq "0" ]; then
           echo "No test files found for e2e target: ${{ inputs.e2e-target }}"
           exit 1

--- a/test-renku-cypress/action.yml
+++ b/test-renku-cypress/action.yml
@@ -73,7 +73,7 @@ runs:
       shell: bash
       run: |
         echo "Looking for tests matching '${{ inputs.e2e-target }}'"
-        match=$(find "${{ inputs.settings-working-directory }}/${{ inputs.e2e-folder }}" -type f -name "${{ inputs.e2e-target }}${{ inputs.e2e-suffix }}" | wc -l)
+        match=$(find "${{ inputs.settings-working-directory }}/${{ inputs.e2e-folder }}" -type f -maxdepth 1 -name "${{ inputs.e2e-target }}${{ inputs.e2e-suffix }}" | wc -l)
         if [ "$match" -eq "0" ]; then
           echo "No test files found for e2e target: ${{ inputs.e2e-target }}"
           exit 1

--- a/test-renku-cypress/action.yml
+++ b/test-renku-cypress/action.yml
@@ -75,7 +75,7 @@ runs:
         echo "Looking for tests matching '${{ inputs.e2e-target }}'"
         match=$(find "${{ inputs.settings-working-directory }}/${{ inputs.e2e-folder }}" -type f -maxdepth 1 -name "${{ inputs.e2e-target }}${{ inputs.e2e-suffix }}" | wc -l)
         if [ "$match" -eq "0" ]; then
-          echo "No test files found for e2e target: ${{ inputs.e2e-target }}"
+          echo "::error::No test files found for e2e target: ${{ inputs.e2e-target }}"
           exit 1
         fi
 

--- a/test-renku-cypress/action.yml
+++ b/test-renku-cypress/action.yml
@@ -62,12 +62,22 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: "Checkout Renku repository"
+    - name: Checkout Renku repository
       uses: actions/checkout@v4
       with:
         repository: ${{ inputs.renku-repository }}
         path: ${{ inputs.renku-path }}
         ref: ${{ inputs.renku-reference }}
+
+    - name: Check e2e target spec exists
+      shell: bash
+      run: |
+        echo "Looking for tests matching '${{ inputs.e2e-target }}'"
+        match=$(find "${{ inputs.e2e-folder }}" -type f -name "${{ inputs.e2e-target }}${{ inputs.e2e-suffix }}" | wc -l)
+        if [ "$match" -eq "0" ]; then
+          echo "No test files found for e2e target: ${{ inputs.e2e-target }}"
+          exit 1
+        fi
 
     - name: Setup Node v22
       uses: actions/setup-node@v4
@@ -76,7 +86,7 @@ runs:
         cache: npm
         cache-dependency-path: ${{ inputs.settings-working-directory }}
 
-    - name: "Run target Cypress test"
+    - name: Run target Cypress test
       uses: cypress-io/github-action@v6
       id: cypress-acceptance-tests
       env:

--- a/test-renku-cypress/action.yml
+++ b/test-renku-cypress/action.yml
@@ -87,8 +87,9 @@ runs:
         cache-dependency-path: ${{ inputs.settings-working-directory }}
 
     - name: Run target Cypress test
-      uses: cypress-io/github-action@v6
       id: cypress-acceptance-tests
+      continue-on-error: true
+      uses: cypress-io/github-action@v6
       env:
         BASE_URL: https://${{ inputs.renku-release }}.dev.renku.ch
         TEST_EMAIL: ${{ inputs.test-user-email }}
@@ -105,13 +106,13 @@ runs:
 
     - name: Create artifact file name
       id: sanitize
-      if: failure()
+      if: steps.cypress-acceptance-tests.outcome == 'failure'
       shell: bash
       run: echo "sanitized=$(echo '${{ inputs.e2e-target }}' | sed 's/[\/]/_/g')" >> $GITHUB_OUTPUT
 
     - name: Upload Cypress screenshot
-      if: failure()
       id: upload-screenshort
+      if: steps.cypress-acceptance-tests.outcome == 'failure' && steps.sanitize.outcome == 'success'
       uses: actions/upload-artifact@v4
       with:
         name: Cypress screenshot - ${{ steps.sanitize.outputs.sanitized }} - ${{ github.run_id }}
@@ -120,7 +121,7 @@ runs:
 
     - name: Upload Cypress video
       id: upload-video
-      if: failure()
+      if: steps.cypress-acceptance-tests.outcome == 'failure' && steps.sanitize.outcome == 'success'
       uses: actions/upload-artifact@v4
       with:
         name: Cypress video - ${{ steps.sanitize.outputs.sanitized }} - ${{ github.run_id }}


### PR DESCRIPTION
This fails the tests when the target spec is missing, so they don't mistakenly appear as passed because the spec for checking the infrastructure still runs.

It also improves the `if: failure()` logic to avoid unnecessary warnings for artifacts.