### PR TITLE
feat:add multi platform support to publish chart

### DIFF
--- a/publish-chart/README.md
+++ b/publish-chart/README.md
@@ -36,3 +36,4 @@ You can set these environment variables:
 | GITHUB_TOKEN         | None        | Yes      |
 | IMAGE_PREFIX         | None        | No       |
 | CHARTPRESS_SPEC_DIR  | .           | No       |
+| PLATFORMS            | linux/amd64 | No       |

--- a/publish-chart/README.md
+++ b/publish-chart/README.md
@@ -19,6 +19,26 @@ It can simply be used as a step in a GitHub actions job:
         GITHUB_TOKEN: ${{ secrets.CI_TOKEN }}
 ```
 
+When doing a multi-platform build:
+
+```yaml
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v3
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+    - uses: SwissDataScienceCenter/renku/actions/publish-chart@master
+      env:
+        CHART_DIR: helm-chart/mychart  # path to the chart directory
+        DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+        DOCKER_PASSWORD: ${{ secrest.DOCKER_PASSWORD }}
+        GITHUB_TOKEN: ${{ secrets.CI_TOKEN }}
+        PLATFORMS: "linux/amd64,linux/arm64"
+```
+
 Note that the `CI_TOKEN` needs write permissions to wherever the chart is
 published to.
 
@@ -37,3 +57,7 @@ You can set these environment variables:
 | IMAGE_PREFIX         | None        | No       |
 | CHARTPRESS_SPEC_DIR  | .           | No       |
 | PLATFORMS            | linux/amd64 | No       |
+
+Platforms can be specified as a comma-separated list of values. For example, to
+build images for amd64 and arm64 platforms, set `PLATFORMS` to
+`linux/amd64,linux/arm64`.

--- a/publish-chart/publish-chart.sh
+++ b/publish-chart/publish-chart.sh
@@ -37,6 +37,19 @@ if [ -z "$CHARTPRESS_SPEC_DIR" ]; then
   CHARTPRESS_SPEC_DIR="."
 fi
 
+PLATFORM_ARGS=""
+BUILDER_ARG=""
+if [ ! -z "$PLATFORMS" ]; then
+  # setting up docker-buildx for multi-platform builds
+  docker buildx create --name multiarch --use
+  docker buildx inspect --bootstrap
+
+  for platform in $(echo $PLATFORMS | tr ',' ' '); do
+    PLATFORM_ARGS="$PLATFORM_ARGS --platform $platform"
+  done
+  BUILDER_ARG="--builder docker-buildx"
+fi
+
 # set up git
 git config --global user.email "$GIT_EMAIL"
 git config --global user.name "$GIT_USER"
@@ -49,4 +62,4 @@ echo ${DOCKER_PASSWORD} | docker login -u ${DOCKER_USERNAME} --password-stdin
 
 # build and push the chart and images
 cd $CHARTPRESS_SPEC_DIR
-chartpress --push --publish-chart $CHART_TAG $IMAGE_PREFIX
+chartpress --push --publish-chart $CHART_TAG $IMAGE_PREFIX $PLATFORM_ARGS $BUILDER_ARG

--- a/publish-chartpress-images/README.md
+++ b/publish-chartpress-images/README.md
@@ -18,6 +18,25 @@ It can simply be used as a step in a GitHub actions job:
         DOCKER_PASSWORD: ${{ secrest.DOCKER_PASSWORD }}
 ```
 
+When doing a multi-platform build:
+
+```yaml
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v3
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+    - uses: SwissDataScienceCenter/renku/actions/publish-chartpress-images@master
+      env:
+        CHART_DIR: helm-chart/mychart  # path to the chart directory
+        DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+        DOCKER_PASSWORD: ${{ secrest.DOCKER_PASSWORD }}
+        PLATFORMS: "linux/amd64,linux/arm64"
+```
+
 ## Configuration
 
 You can set these environment variables:
@@ -32,8 +51,9 @@ You can set these environment variables:
 | PUSH_LATEST          | None        | No       |
 | PLATFORMS            | linux/amd64 | No       |
 
-Note: setting the `PUSH_LATEST` variable to any non-zero value will trigger the publishing of
-the images with the `latest` tag.
+Note: setting the `PUSH_LATEST` variable to any non-zero value will trigger the
+publishing of the images with the `latest` tag.
 
-Platforms can be specified as a comma-separated list of values. For example, to build images for amd64 and arm64 platforms, set `PLATFORMS` to `linux/amd64,linux/arm64`.
-
+Platforms can be specified as a comma-separated list of values. For example, to
+build images for amd64 and arm64 platforms, set `PLATFORMS` to
+`linux/amd64,linux/arm64`.


### PR DESCRIPTION
## Describe your changes

This PR updates the publish-chart action so that it can also be used for multi-platform builds as publish-chartpress-images does.

The documentation of both actions is also updated to contain examples for multi-platform builds as they require the installation of additional components to be able to use `docker buildx`.