### PR TITLE
feat: add azure login to deploy

### DIFF
--- a/deploy-renku/Dockerfile
+++ b/deploy-renku/Dockerfile
@@ -2,10 +2,11 @@ FROM alpine/k8s:1.23.17
 
 # install dependencies
 COPY requirements.txt /
-RUN apk add --no-cache python3 docker jq && \
+RUN apk add --no-cache python3 python3-dev docker jq gcc musl-dev linux-headers && \
     wget -O /usr/bin/yq "https://github.com/mikefarah/yq/releases/download/v4.45.1/yq_linux_amd64" && \
     chmod a+x /usr/bin/yq && \
-    pip3 install -r /requirements.txt
+    pip3 install -r /requirements.txt && \
+    apk del python3-dev gcc musl-dev linux-headers
 
 COPY deploy-dev-renku.py entrypoint.sh /
 ENTRYPOINT /entrypoint.sh

--- a/deploy-renku/action.yml
+++ b/deploy-renku/action.yml
@@ -6,3 +6,21 @@ runs:
 branding:
   icon: 'activity'
   color: 'blue'
+inputs:
+  azure_login:
+    description: "Whether to log into Azure and get a kubeconfig, set to 'true' to enable it. Other 'truthy' values will not be treated as true."
+    required: false
+    default: "false"
+  azure_client_id:
+    description: "Azure client ID, required if azure-login is set to true."
+    required: false
+  azure_tenant_id:
+    description: "Azure tenant ID, required if azure-login is set to true."
+    required: false
+  azure_subscription_id:
+    description: "Azure subscription ID, required if azure-login is set to true."
+    required: false
+  azure_resource_group:
+    description: "The azure resource group to be used"
+    required: false
+    default: "renku-dev"

--- a/deploy-renku/action.yml
+++ b/deploy-renku/action.yml
@@ -21,6 +21,6 @@ inputs:
     description: "Azure subscription ID, required if azure-login is set to true."
     required: false
   azure_resource_group:
-    description: "The azure resource group to be used"
+    description: "The azure resource group to be used, required if azure-login is set to true."
     required: false
     default: "renku-dev"

--- a/deploy-renku/entrypoint.sh
+++ b/deploy-renku/entrypoint.sh
@@ -15,7 +15,7 @@ if [ "$INPUT_AZURE_LOGIN" = "true" ]; then
     echo "Azure subscription id is not set, but you requested to log in with Azure."
     exit 1
   fi
-  az login --tentant "$INPUT_AZURE_TENANT_ID" --client-id "$INPUT_AZURE_CLIENT_ID"
+  az login --tenant "$INPUT_AZURE_TENANT_ID" --client-id "$INPUT_AZURE_CLIENT_ID"
   az account set --subscription "$INPUT_AZURE_SUBSCRIPTION_ID"
   az aks get-credentials --resource-group "$INPUT_AZURE_RESOURCE_GROUP" --name aks-switzerlandnorth-renku-dev
 fi

--- a/deploy-renku/entrypoint.sh
+++ b/deploy-renku/entrypoint.sh
@@ -32,7 +32,7 @@ export TLS_SECRET_NAME="${RENKU_RELEASE}-ch-tls"
 echo $DOCKER_PASSWORD | docker login -u $DOCKER_USERNAME --password-stdin
 
 # set up kube context and values file
-if [ -n "$RENKUBOT_KUBECONFIG" ]; then
+if [ -n "$RENKUBOT_KUBECONFIG" ] && [ -n "$KUBECONFIG" ]; then
   echo "$RENKUBOT_KUBECONFIG" >"$KUBECONFIG" && chmod 400 "$KUBECONFIG"
 fi
 

--- a/deploy-renku/entrypoint.sh
+++ b/deploy-renku/entrypoint.sh
@@ -15,8 +15,8 @@ if [ "$INPUT_AZURE_LOGIN" = "true" ]; then
     echo "Azure subscription id is not set, but you requested to log in with Azure."
     exit 1
   fi
-  az account set --subscription "$INPUT_AZURE_SUBSCRIPTION_ID"
   az login --tentant "$INPUT_AZURE_TENANT_ID" --client-id "$INPUT_AZURE_CLIENT_ID"
+  az account set --subscription "$INPUT_AZURE_SUBSCRIPTION_ID"
   az aks get-credentials --resource-group "$INPUT_AZURE_RESOURCE_GROUP" --name aks-switzerlandnorth-renku-dev
 fi
 

--- a/deploy-renku/requirements.txt
+++ b/deploy-renku/requirements.txt
@@ -2,7 +2,8 @@ chartpress==2.1.0
 kubernetes
 packaging
 json-merge-patch
-ruamel.yaml<0.17.10
-ruamel.yaml.clib<0.2.4
+ruamel.yaml==0.18.14
+ruamel.yaml.clib==0.2.12
 # requests 2.32.0 has a bug with not allowing docker+http protocol, see requests/issues/6707
 requests<2.32.0
+azure-cli==2.76.0


### PR DESCRIPTION
I am opening and closing this as a record of what did not work.

The problem occurs because the azure login github action has more magic for logging in than what is available in the azure python sdk or in the azure cli. This is included in javascript libraries that we cannot access easily from the shell or python code in our custom renku-deploy action.