### PR TITLE
chore: label and annotate CI deployment namespaces

### DIFF
--- a/deploy-renku/entrypoint.sh
+++ b/deploy-renku/entrypoint.sh
@@ -51,7 +51,15 @@ if test -n "$GITLAB_TOKEN" ; then
 fi
 
 # create namespace and ignore error in case it already exists
-kubectl create namespace ${RENKU_NAMESPACE} || true
+kubectl create namespace "${RENKU_NAMESPACE}" || true
+kubectl label ns "${RENKU_NAMESPACE}" "renku.io/ci-deployment=true"
+
+if [ -n "$PR_URL" ]; then
+  # NOTE: That a full url cannot be used as a label value because label values have a more restricted
+  # set of characters that are allowed and some of the special characters in urls are possible in annotations
+  # but not for labels.
+  kubectl patch ns "${RENKU_NAMESPACE}" --patch "{\"metadata\": {\"annotations\": {\"renku.io/pr-url\": \"${PR_URL}\"}}}"
+fi
 
 # deploy renku - reads config from environment variables
 helm repo add renku https://swissdatasciencecenter.github.io/helm-charts


### PR DESCRIPTION
This will help us to find namespaces for CI deployments quicker. Because right now we have to use some regex to check which namespace is and is not for a CI deployment.

Also if we set the PR_URL env variable in the action then we can have the link to the PR that triggered the CI deployment. Currently we also have to put togther the PR url (from the release name) and check the state of the PR when we clean up.